### PR TITLE
Check method exists first before instantiating

### DIFF
--- a/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -97,7 +97,7 @@ abstract class AbstractServiceProvider extends BaseServiceProvider {
 		if ( ! isset( $concrete ) || is_string( $concrete ) && class_exists( $concrete ) ) {
 			try {
 				$class  = $concrete ?? $class_name;
-				$method = new \ReflectionMethod( $class, Definition::INJECTION_METHOD );
+				$method = method_exists($class, Definition::INJECTION_METHOD) ? new \ReflectionMethod( $class, Definition::INJECTION_METHOD ) : null;
 				if ( ! isset( $method ) ) {
 					return null;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29465.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

A ReflectionException is thrown in the constructor for ReflectionMethod as detailed at https://www.php.net/manual/en/reflectionmethod.construct.php. The assumption is that null is returned if ReflectionMethod cannot be instantiated. This amend checks whether the method exists, creates a ReflectionMethod instance if it does or null otherwise.
